### PR TITLE
Add Self:: before local constants

### DIFF
--- a/src/News.php
+++ b/src/News.php
@@ -23,16 +23,16 @@ class News
     public function get($type, $lang = Language::ENGLISH)
     {
         if ($lang !== Language::ENGLISH
-            && $lang !== Language::GERMAN 
-            && $lang !== Language::SPANISH 
-            && $lang !== Language::CHINESE 
-            && $lang !== Language::FRENCH 
-            && $lang !== Language::FRENCH 
-            && $lang !== Language::ITALIAN 
+            && $lang !== Language::GERMAN
+            && $lang !== Language::SPANISH
+            && $lang !== Language::CHINESE
+            && $lang !== Language::FRENCH
+            && $lang !== Language::FRENCH
+            && $lang !== Language::ITALIAN
             && $lang !== Language::JAPANESE)
                 throw new \Exception("Unknown Language");
 
-        if ($type != SAVETHEWORLD && $type != BATTLEROYALE)
+        if ($type != Self::SAVETHEWORLD && $type != Self::BATTLEROYALE)
             throw new \Exception("Only SaveTheWorld and BattleRoyale news are currently supported");
 
         try {


### PR DESCRIPTION
I'm not sure if this is an issue, but I got problems getting constants `SAVETHEWORLD `and `BATTLEROYALE` of news module. 

`<br />
<b>Warning</b>:  Use of undefined constant SAVETHEWORLD - assumed 'SAVETHEWORLD'`

Maybe adding Self before constants:

```
35        if ($type != Self::SAVETHEWORLD && $type != Self::BATTLEROYALE)
36            throw new \Exception("Only SaveTheWorld and BattleRoyale news are currently supported");
```
Solves the problem.