### PR TITLE
Auto accept EULA for new accounts

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -32,12 +32,15 @@ class Auth {
         $this->refresh_token = $refresh_token;
         $this->account_id = $account_id;
         $this->expires_in = $expires_in;
+        $this->account = new Account($this->access_token,$this->account_id);
+        $this->status = new Status($this->access_token);
+        if ($this->status->allowedToPlay() === false){
+            $this->account->acceptEULA();
+        }
         $this->profile = new Profile($this->access_token, $this->account_id);
-        $this->account = new Account($this->access_token);
         $this->leaderboard  = new Leaderboard($this->access_token, $this->in_app_id, $this->account);
         $this->store = new Store($this->access_token);
         $this->news = new News($this->access_token);
-        $this->status = new Status($this->access_token);
     }
 
     /**

--- a/src/FortniteClient.php
+++ b/src/FortniteClient.php
@@ -34,6 +34,7 @@ class FortniteClient {
     const FORTNITE_ACCOUNT_API          = "https://account-public-service-prod03.ol.epicgames.com/account/api/";
     const FORTNITE_NEWS_API             = "https://fortnitecontent-website-prod07.ol.epicgames.com/content/api/";
     const FORTNITE_STATUS_API           = "https://lightswitch-public-service-prod06.ol.epicgames.com/lightswitch/api/";
+    const FORTNITE_EULA_API             = "https://eulatracking-public-service-prod-m.ol.epicgames.com/eulatracking/api/";
 
 
 

--- a/src/Status.php
+++ b/src/Status.php
@@ -27,4 +27,16 @@ class Status
             throw $e;
         }
     }
+
+    public function allowedToPlay(){
+        try {
+            $data = FortniteClient::sendFortniteGetRequest(FortniteClient::FORTNITE_STATUS_API . 'service/bulk/status?serviceId=Fortnite',
+                $this->access_token);
+
+            return !empty($data[0]->allowedActions) && in_array('PLAY',$data[0]->allowedActions);
+        } catch (GuzzleException $e) {
+            if ($e->getResponse()->getStatusCode() == 404) throw new \Exception('Unable to obtain Fortnite status.');
+            throw $e;
+        }
+    }
 }


### PR DESCRIPTION
New accounts need to accept the End User License Agreement before being able to play or view the leader-boards.
I added the necessary calls to the API in order to accept the EULA and grant the required permission.