### PR TITLE
Add support for handling friends requests

### DIFF
--- a/src/FortniteClient.php
+++ b/src/FortniteClient.php
@@ -95,6 +95,31 @@ class FortniteClient {
     }
 
     /**
+     * Sends a DELETE request as the Unreal Engine Client.
+     * @param  string  $endpoint      API Endpoint to request
+     * @param  string  $authorization Authorization header
+     * @param  boolean $oauth         Is $authorization an OAuth2 token
+     * @return object                 Decoded JSON response body
+     */
+    public static function sendUnrealClientDeleteRequest($endpoint, $authorization = self::EPIC_LAUNCHER_AUTHORIZATION, $oauth = false) {
+        $client = new Client(['http_errors' => false]);
+
+        try {
+            $response = $client->delete($endpoint, [
+                'headers' => [
+                    'User-Agent' => self::UNREAL_CLIENT_USER_AGENT,
+                    'Authorization' => (!$oauth) ? 'basic ' . $authorization : 'bearer ' . $authorization,
+                    'X-Epic-Device-ID' => self::generateDeviceId()
+                ]
+            ]);
+
+            return json_decode($response->getBody()->getContents());
+        } catch (GuzzleException $e) {
+            throw $e; //Throw exception back up to caller
+        }
+    }
+
+    /**
      * Sends a GET request as the Fortnite client.
      * @param  string $endpoint     API endpoint to request
      * @param  string $access_token OAuth2 access token

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -41,10 +41,26 @@ class Profile {
 
     /**
      * Get current user's friends on Unreal Engine.
+     * @param  boolean  Whether to include friend requests and suggestions. False by default.
      * @return array    Array of friends
      */
-    public function getFriends() {
-        $data = FortniteClient::sendUnrealClientGetRequest(FortniteClient::EPIC_FRIENDS_ENDPOINT . $this->account_id, $this->access_token, true);
+    public function getFriends($includePending = false) {
+        $data = FortniteClient::sendUnrealClientGetRequest(FortniteClient::EPIC_FRIENDS_ENDPOINT . $this->account_id .
+            '?includePending=' . ($includePending ? 'true' : 'false'),
+                                                        $this->access_token,
+                                                        true);
+
+        return $data;
+    }
+
+    /**
+     * Remove a friend or decline a friend request on Unreal Engine.
+     * @param string    ID of friend to remove
+     */
+    public function removeFriend($id) {
+        $data = FortniteClient::sendUnrealClientDeleteRequest(FortniteClient::EPIC_FRIENDS_ENDPOINT . $this->account_id . '/' . $id,
+                                                        $this->access_token,
+                                                        new \StdClass());
 
         return $data;
     }


### PR DESCRIPTION
This pull request does the following:

 * Adds a new `sendUnrealClientDeleteRequest` static method to `FortniteClient.php` for sending `DELETE` requests to Unreal Client endpoints
 * Adds a new parameter to `getFriends` in `Profile.php` that allows the user to specify if the response should include friend requests or not. False by default.
 * Adds a new function called `removeFriend($id)` to `Profile.php` that allows to reject a friends request or remove a friend (both actions use the same endpoint)